### PR TITLE
Verify that user can't sign in with empty Email/Password field, error message appears

### DIFF
--- a/helpers/testData.js
+++ b/helpers/testData.js
@@ -30,6 +30,8 @@ export const CREATE_ACCOUNT_PAGE_PASSWORD_CONFIRMATION_ERROR = "Please enter the
 export const CREATE_ACCOUNT_PAGE_EMPTY_FIELD_ERROR_MESSAGE = "This is a required field.";
 export const NAVBAR_MENU = ["What's New", "Women", "Men", "Gear", "Training", "Sale"];
 export const LOGIN_PAGE_HEADER = "Customer Login";
+export const LOGIN_PAGE_FIELDS = ["Email", "Password"];
+export const LOGIN_PAGE_EMPTY_FIELD_ERROR_MESSAGE = "This is a required field.";
 
 // Login credentials
 export const NEW_USER_DATA = {

--- a/page_objects/loginPage.js
+++ b/page_objects/loginPage.js
@@ -7,9 +7,10 @@ class LoginPage {
 
   locators = {
     getPageHeader: () => this.page.getByRole("heading").first(),
-    getEmailField: () => this.page.getByLabel("Email"),
+    getEmailField: () => this.page.getByLabel("Email", { exact: true }),
     getPasswordField: () => this.page.getByLabel("Password"),
     getSignInButton: () => this.page.getByRole("button", { name: "Sign In", exact: true }),
+    getFieldErrorMessage: (fieldName) => this.page.locator(`input[title="${fieldName}"]+div`),
   }
 
   async fillEmailField (email) {

--- a/tests/loginPage.spec.js
+++ b/tests/loginPage.spec.js
@@ -3,7 +3,9 @@ import HomePage from "../page_objects/homePage.js";
 import { BASE_URL,
   EXISTING_USER_DATA,
   HOME_PAGE_TITLE,
+  LOGIN_PAGE_EMPTY_FIELD_ERROR_MESSAGE,
   LOGIN_PAGE_END_POINT,
+  LOGIN_PAGE_FIELDS,
   LOGIN_PAGE_HEADER } from "../helpers/testData.js";
 
 test.describe("loginPage.spec", () => {
@@ -32,5 +34,21 @@ test.describe("loginPage.spec", () => {
     await expect(page).toHaveURL(BASE_URL);
     await expect(homePage.locators.getWelcomeMessage()).toHaveText(EXISTING_USER_DATA.welcomeMessage);
     await expect(page).toHaveTitle(HOME_PAGE_TITLE);
+  });
+
+  LOGIN_PAGE_FIELDS.forEach(fieldName => {
+    test(`Verify that user can't sign in with empty "${fieldName}" field, error message appears`, async ({ page }) => {
+      const homePage = new HomePage(page);
+      const loginPage = await homePage.clickSignInLink();
+
+      fieldName === "Email" ? null : await loginPage.fillEmailField(EXISTING_USER_DATA.email);
+      fieldName === "Password" ? null : await loginPage.fillPasswordField(EXISTING_USER_DATA.password);
+      await loginPage.clickSignInButton();
+
+      await expect(page).toHaveURL(BASE_URL + LOGIN_PAGE_END_POINT);
+      await expect(loginPage.locators.getPageHeader()).toHaveText(LOGIN_PAGE_HEADER);
+      await expect(loginPage.locators.getFieldErrorMessage(fieldName)).toBeVisible();
+      await expect(loginPage.locators.getFieldErrorMessage(fieldName)).toHaveText(LOGIN_PAGE_EMPTY_FIELD_ERROR_MESSAGE);
+    });
   });
 })


### PR DESCRIPTION
https://trello.com/c/cfM9HP3U/858-tc-10115-verify-that-user-cant-sign-in-with-empty-email-field-error-message-appears
https://trello.com/c/BpuiKba1/859-tc-10116-verify-that-user-cant-sign-in-with-empty-password-field-error-message-appears